### PR TITLE
Use quit-window to quit the xref buffer

### DIFF
--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -61,8 +61,7 @@
   ;; immediately since we don't want to see it - see
   ;; https://github.com/alexmurray/ivy-xref/issues/2
   (let ((buffer (xref--show-xref-buffer xrefs alist)))
-    (bury-buffer buffer)
-    (delete-window)
+    (quit-window)
     (ivy-read "xref: " (ivy-xref-make-collection xrefs)
               :require-match t
               :sort t


### PR DESCRIPTION
Hi!

I noticed that ivy-xref always deletes one window when displaying the list of
xrefs, even when xref didn't open one, and it's rather annoying since it
disturbs my window configuration quite a bit each time xref returns with a
list instead of a single match.

I found that the function `quit-window` does what the code is doing, but more
intelligently, in particular it restores the previous buffer if the window has
one. It is also the command mapped to the `q` key in the `*xref*` buffer
itself.

I wonder if you'd be willing to merge this into master.

Thanks.