### PR TITLE
Display file path.

### DIFF
--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -35,6 +35,10 @@
 (require 'xref)
 (require 'ivy)
 
+(defcustom ivy-xref-use-file-path nil
+  "Whether to display the file path."
+  :type 'boolean)
+
 (defun ivy-xref-make-collection (xrefs)
   "Transform XREFS into a collection for display via `ivy-read'."
   (let ((collection nil))
@@ -44,6 +48,7 @@
               (file (xref-location-group location))
               (candidate nil))
           (setq candidate (concat
+			   (when ivy-xref-use-file-path file)
                            ;; use file name only
                            (car (reverse (split-string file "\\/")))
                                   (when (string= "integer" (type-of line))


### PR DESCRIPTION
I have the same file name when I look up the definition, and I think the display path is helpful for better analysis.
![image](https://user-images.githubusercontent.com/19857153/40222879-9a5de57a-5ab3-11e8-956a-08bd919028ec.png)
