### PR TITLE
Improve location display

### DIFF
--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -51,20 +51,22 @@
   (let ((collection nil))
     (dolist (xref xrefs)
       (with-slots (summary location) xref
-        (let ((line (xref-location-line location))
-              (file (xref-location-group location))
-              (candidate nil))
-          (setq candidate (concat
-                           (propertize
-                            (concat
-                             (if ivy-xref-use-file-path
-                                 file
-                               ;; use file name only
-                               (car (reverse (split-string file "\\/"))))
-                             (when (string= "integer" (type-of line))
-                               (concat ":" (int-to-string line) ": ")))
-                            'face 'compilation-info)
-                           summary))
+        (let* ((line (xref-location-line location))
+               (file (xref-location-group location))
+               (candidate
+                 (concat
+                  (propertize
+                   (concat
+                    (if ivy-xref-use-file-path
+                        file
+                      ;; use file name only
+                      (car (reverse (split-string file "\\/"))))
+                    ":"
+                    (when (string= "integer" (type-of line))
+                      (concat (int-to-string line) ":"))
+                    " ")
+                   'face 'compilation-info)
+                  summary)))
           (push `(,candidate . ,location) collection))))
     (nreverse collection)))
 

--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -46,7 +46,7 @@
   :type 'boolean
   :group 'ivy-xref)
 
-(defcustom ivy-xref-remove-properties nil
+(defcustom ivy-xref-remove-text-properties nil
   "Whether to display the candidates with their original faces."
   :type 'boolean
   :group 'ivy-xref)
@@ -70,7 +70,7 @@
                       ": "))
                    'face 'compilation-info)
                   (progn
-                    (when ivy-xref-remove-properties
+                    (when ivy-xref-remove-text-properties
                       (set-text-properties 0 (length summary) nil summary))
                     summary))))
           (push `(,candidate . ,location) collection))))

--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -46,6 +46,11 @@
   :type 'boolean
   :group 'ivy-xref)
 
+(defcustom ivy-xref-remove-properties nil
+  "Whether to display the candidates with their original faces."
+  :type 'boolean
+  :group 'ivy-xref)
+
 (defun ivy-xref-make-collection (xrefs)
   "Transform XREFS into a collection for display via `ivy-read'."
   (let ((collection nil))
@@ -66,7 +71,10 @@
                       (concat (int-to-string line) ":"))
                     " ")
                    'face 'compilation-info)
-                  summary)))
+                  (progn
+                    (when ivy-xref-remove-properties
+                      (set-text-properties 0 (length summary) nil summary))
+                    summary))))
           (push `(,candidate . ,location) collection))))
     (nreverse collection)))
 

--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -55,12 +55,15 @@
               (file (xref-location-group location))
               (candidate nil))
           (setq candidate (concat
-                           (if ivy-xref-use-file-path
-                               file
-                             ;; use file name only
-                             (car (reverse (split-string file "\\/"))))
-                           (when (string= "integer" (type-of line))
-                             (concat ":" (int-to-string line) ": "))
+                           (propertize
+                            (concat
+                             (if ivy-xref-use-file-path
+                                 file
+                               ;; use file name only
+                               (car (reverse (split-string file "\\/"))))
+                             (when (string= "integer" (type-of line))
+                               (concat ":" (int-to-string line) ": ")))
+                            'face 'compilation-info)
                            summary))
           (push `(,candidate . ,location) collection))))
     (nreverse collection)))

--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -64,12 +64,10 @@
                    (concat
                     (if ivy-xref-use-file-path
                         file
-                      ;; use file name only
-                      (car (reverse (split-string file "\\/"))))
-                    ":"
-                    (when (string= "integer" (type-of line))
-                      (concat (int-to-string line) ":"))
-                    " ")
+                      (file-name-nondirectory file))
+                    (if (integerp line)
+                        (format ":%d: " line)
+                      ": "))
                    'face 'compilation-info)
                   (progn
                     (when ivy-xref-remove-properties


### PR DESCRIPTION
To get something similar to grep results:

- use compilation-info face
- use colon character even when line number is not displayed

also add a customization option to remove text properties from completion candidates.
related:  #3

example:
![image](https://user-images.githubusercontent.com/7757342/44349662-d24ecb00-a49d-11e8-93cd-b216e12bef51.png)
