### PR TITLE
Emacs 27 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To enable then simply add the following to your init file:
 ```emacs-lisp
 (require 'ivy-xref)
 ;; Emacs 27 only:
-(setq xref-show-definitions-function #'ivy-xref-show-xrefs)
+(setq xref-show-definitions-function #'ivy-xref-show-defs)
 ;; Necessary in Emacs <27. In Emacs 27 it will affect all xref-based commands
 ;; other than xref-find-definitions (e.g. project-find-regexp):
 (setq xref-show-xrefs-function #'ivy-xref-show-xrefs)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ To enable then simply add the following to your init file:
 
 ```emacs-lisp
 (require 'ivy-xref)
+(setq xref-show-definitions-function #'ivy-xref-show-xrefs)
+;; And optionally (for e.g. M-x project-find-regexp output):
 (setq xref-show-xrefs-function #'ivy-xref-show-xrefs)
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ To enable then simply add the following to your init file:
 
 ```emacs-lisp
 (require 'ivy-xref)
+;; Emacs 27 only:
 (setq xref-show-definitions-function #'ivy-xref-show-xrefs)
-;; And optionally (for e.g. M-x project-find-regexp output):
+;; Necessary in Emacs <27. In Emacs 27 it will affect all xref-based commands
+;; other than xref-find-definitions (e.g. project-find-regexp):
 (setq xref-show-xrefs-function #'ivy-xref-show-xrefs)
 ```
 

--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -118,5 +118,17 @@
     ;; return value
     buffer))
 
+;;;###autoload
+(defun ivy-xref-show-defs (fetcher alist)
+  (let ((xrefs (funcall fetcher)))
+    (cond
+     ((not (cdr xrefs))
+      (xref-pop-to-location (car xrefs)
+                            (assoc-default 'display-action alist)))
+     (t
+      (ivy-xref-show-xrefs fetcher
+                           (cons (cons 'fetched-xrefs xrefs)
+                                 alist))))))
+
 (provide 'ivy-xref)
 ;;; ivy-xref.el ends here

--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -77,14 +77,19 @@
     (nreverse collection)))
 
 ;;;###autoload
-(defun ivy-xref-show-xrefs (xrefs alist)
-  "Show the list of XREFS and ALIST via ivy."
+(defun ivy-xref-show-xrefs (fetcher alist)
+  "Show the list of xrefs returned by FETCHER and ALIST via ivy."
   ;; call the original xref--show-xref-buffer so we can be used with
   ;; dired-do-find-regexp-and-replace etc which expects to use the normal xref
   ;; results buffer but then bury it and delete the window containing it
   ;; immediately since we don't want to see it - see
   ;; https://github.com/alexmurray/ivy-xref/issues/2
-  (let ((buffer (xref--show-xref-buffer xrefs alist)))
+  (let* ((xrefs (if (functionp fetcher)
+                    ;; Emacs 27
+                    (or (assoc-default 'fetched-xrefs alist)
+                        (funcall fetcher))
+                    fetcher))
+         (buffer (xref--show-xref-buffer fetcher alist)))
     (quit-window)
     (let ((orig-buf (current-buffer))
           (orig-pos (point))


### PR DESCRIPTION
There are changes in Emacs master that change the calling convention of `xref-show-xrefs-function` and add `xref-show-definitions-function`.