### PR TITLE
README: setup: set xref-show-xrefs-function in emacs 27 as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ To enable then simply add the following to your init file:
 ```emacs-lisp
 (require 'ivy-xref)
 ;; XRef initialization is different in Emacs 27
-(if (< emacs-major-version 27)
-    ;; Necessary in Emacs <27. In Emacs 27 it will affect all xref-based
-    ;; commands other than xref-find-definitions
-    ;; (e.g. project-find-regexp):
-    (setq xref-show-xrefs-function #'ivy-xref-show-xrefs)
-  ;; Emacs 27 only:
+(unless (< emacs-major-version 27)
   (setq xref-show-definitions-function #'ivy-xref-show-defs))
+;; In Emacs 27 it will affect all xref-based
+;; commands other than xref-find-definitions
+;; (e.g. project-find-regexp):
+(setq xref-show-xrefs-function #'ivy-xref-show-xrefs)
 ```
 
 We recommend to use [use-package](https://github.com/jwiegley/use-package) to
@@ -37,9 +36,10 @@ make this automatic:
 ```emacs-lisp
 (use-package ivy-xref
   :ensure t
-  :init (if (< emacs-major-version 27)
-            (setq xref-show-xrefs-function #'ivy-xref-show-xrefs)
-          (setq xref-show-definitions-function #'ivy-xref-show-defs)))
+  :init
+  (unless (< emacs-major-version 27)
+    (setq xref-show-definitions-function #'ivy-xref-show-defs))
+  (setq xref-show-xrefs-function #'ivy-xref-show-xrefs))
 ```
 
 ### Manual installation


### PR DESCRIPTION
Otherwise, using xref-find-definitions does not trigger code from this
package.