### PR TITLE
Fix invalid reference to buffer

### DIFF
--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -90,7 +90,7 @@
                         (funcall fetcher))
                     fetcher))
          (buffer (xref--show-xref-buffer fetcher alist)))
-    (quit-window)
+    (quit-window t)
     (let ((orig-buf (current-buffer))
           (orig-pos (point))
           done)


### PR DESCRIPTION
It looks like the `(quit-window)` invalidates the reference for `buffer` in

https://github.com/alexmurray/ivy-xref/blob/3d4c35fe2b243d948d8fe02a1f0d76a249d63de9/ivy-xref.el#L87-L93

I discovered that `(quit-window t)` (i.e. with `&optional kill`) doesn't somehow do that... This fixes #17.