### PR TITLE
Stop using 'with-slots'

### DIFF
--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -55,25 +55,26 @@
   "Transform XREFS into a collection for display via `ivy-read'."
   (let ((collection nil))
     (dolist (xref xrefs)
-      (with-slots (summary location) xref
-        (let* ((line (xref-location-line location))
-               (file (xref-location-group location))
-               (candidate
-                 (concat
-                  (propertize
-                   (concat
-                    (if ivy-xref-use-file-path
-                        file
-                      (file-name-nondirectory file))
-                    (if (integerp line)
-                        (format ":%d: " line)
-                      ": "))
-                   'face 'compilation-info)
-                  (progn
-                    (when ivy-xref-remove-text-properties
-                      (set-text-properties 0 (length summary) nil summary))
-                    summary))))
-          (push `(,candidate . ,location) collection))))
+      (let* ((summary (xref-item-summary xref))
+             (location  (xref-item-location xref))
+             (line (xref-location-line location))
+             (file (xref-location-group location))
+             (candidate
+              (concat
+               (propertize
+                (concat
+                 (if ivy-xref-use-file-path
+                     file
+                   (file-name-nondirectory file))
+                 (if (integerp line)
+                     (format ":%d: " line)
+                   ": "))
+                'face 'compilation-info)
+               (progn
+                 (when ivy-xref-remove-text-properties
+                   (set-text-properties 0 (length summary) nil summary))
+                 summary))))
+        (push `(,candidate . ,location) collection)))
     (nreverse collection)))
 
 ;;;###autoload


### PR DESCRIPTION
The latest Xref is not based on EIEIO anymore, so with-slots and oref don't work.

Use accessor functions which work with both implementations (old and new).