### PR TITLE
export to *xref*

### DIFF
--- a/ivy-xref.el
+++ b/ivy-xref.el
@@ -110,6 +110,14 @@
                                        (xref--show-pos-in-buf marker buf t)
                                      (xref--show-pos-in-buf marker buf)))))
                             (user-error (message (error-message-string err)))))
+                :keymap
+                (let ((map (make-sparse-keymap)))
+                  (define-key map (kbd "C-c C-o")
+                    (lambda ()
+                      (interactive)
+                      (ivy-quit-and-run
+                        (xref--show-xref-buffer fetcher alist))))
+                  map)
                 :unwind (lambda ()
                           (unless done
                             (switch-to-buffer orig-buf)


### PR DESCRIPTION
This PR allows to export the current ivy xref result set to `*xref*` buffer  (https://www.gnu.org/software/emacs/manual/html_node/emacs/Xref-Commands.html).

The export command is bound to `C-c C-o`.

`ivy` also provides a generic export `ivy-occur` but it is not as powerful as this one.

Thanks.